### PR TITLE
Bugfix with lexical scoping

### DIFF
--- a/compiler/frontend/src/ccomp/parser_hw/CCompiler.java
+++ b/compiler/frontend/src/ccomp/parser_hw/CCompiler.java
@@ -224,7 +224,7 @@ public class CCompiler {
 					if (found) {
 						name = prefix + "$" + name;
 					}
-					if (!found && prefix.startsWith("LEXICAL_RESET_SEPARATOR")) {
+					if (!found && prefix.startsWith(LEXICAL_RESET_SEPARATOR)) {
 						break; // Don't look below lexical_reset: prefixes.
 					}
 				}


### PR DESCRIPTION
The string constant "LEXICAL_RESET_SEPARATOR" vs the string global constant LEXICAL_RESET_SEPARATOR (which has a value of "#".)

Fixes issues 53.